### PR TITLE
Update sklearn to scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ipython<8.0,>=7.23.1
 pandas
-sklearn
+scikit-learn
 numpy
 nltk
 textblob


### PR DESCRIPTION
A learner on the platform got the following due to the legacy `sklearn` requirement:

```
 Downloading sklearn-0.0.post12.tar.gz (2.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
```

This just updates the dependency (verified on the platform).